### PR TITLE
add blosc2 compression

### DIFF
--- a/asdf_compression/_tests/test_labels.py
+++ b/asdf_compression/_tests/test_labels.py
@@ -57,7 +57,7 @@ def _roundtrip(tmp_path, tree, compression=None, write_options=None, read_option
     return tmpfile
 
 
-@pytest.mark.parametrize("label", ["blsc", "lz4f", "zstd"])
+@pytest.mark.parametrize("label", ["blsc", "lz4f", "zstd", "bls2"])
 def test_label(tmp_path, label):
     tree = _get_large_tree()
     _roundtrip(tmp_path, tree, label)

--- a/asdf_compression/bls2/__init__.py
+++ b/asdf_compression/bls2/__init__.py
@@ -1,0 +1,4 @@
+from .extensions import get_extensions
+
+
+__all__ = ["get_extensions"]

--- a/asdf_compression/bls2/compressor.py
+++ b/asdf_compression/bls2/compressor.py
@@ -1,0 +1,16 @@
+from asdf.extension import Compressor
+
+
+class Blosc2Compressor(Compressor):
+    label = b"bls2"
+
+    def compress(self, data, **kwargs):
+        import blosc2
+
+        yield blosc2.compress(data, **kwargs)
+
+    def decompress(self, data, out, **kwargs):
+        import blosc2
+
+        out[:] = blosc2.decompress(b"".join(data), **kwargs)
+        return out.nbytes

--- a/asdf_compression/bls2/extensions.py
+++ b/asdf_compression/bls2/extensions.py
@@ -1,0 +1,16 @@
+import asdf
+
+from asdf_compression._utils import _module_available
+
+from .compressor import Blosc2Compressor
+
+
+class Blosc2Extension(asdf.extension.Extension):
+    extension_uri = "asdf://asdf-format.org/compression/extensions/bls2-1.0.0"
+    compressors = [Blosc2Compressor()]
+
+
+def get_extensions():
+    if _module_available("blosc2"):
+        return [Blosc2Extension()]
+    return []

--- a/asdf_compression/extensions.py
+++ b/asdf_compression/extensions.py
@@ -1,7 +1,8 @@
 from . import blsc
+from . import bls2
 from . import lz4f
 from . import zstd
 
 
 def get_extensions():
-    return blsc.get_extensions() + lz4f.get_extensions() + zstd.get_extensions()
+    return blsc.get_extensions() + bls2.get_extensions() + lz4f.get_extensions() + zstd.get_extensions()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,9 @@ tests = [
 blsc = [
    "blosc>=1.9.2",
 ]
+bls2 = [
+   "blosc2>=3.12.2",
+]
 lz4f = [
   "lz4>=0.10",
 ]
@@ -31,7 +34,7 @@ zstd = [
   "zstandard >= 0.21.0",
 ]
 all = [
-  "asdf_compression[blsc,lz4f,zstd]"
+  "asdf_compression[blsc,lz4f,zstd,bls2]"
 ]
 
 [project.urls]


### PR DESCRIPTION
Adds support for blosc2 compression using the label "bls2" (since we're limited to 4 characters).